### PR TITLE
Fix: prevent overflow and enable scrolling on mobile

### DIFF
--- a/src/components/login.svelte
+++ b/src/components/login.svelte
@@ -116,8 +116,10 @@
     position: fixed;
     inset: 0;
     margin: auto;
-    width: 500px;
+    width: min(500px, calc(100% - 40px));
+    max-height: 100%;
     height: fit-content;
+    overflow-y: auto;
 
     input,
     button {


### PR DESCRIPTION
The login box was wider than the screen on mobile, cutting off the Load button

The page also couldn't be scrolled when the content was taller than the viewport

Tested on iPhone 16 Pro (Safari 26.5) and with Firefox "inspect element" (Responsive Design Mode)

My feed completely stopped working a few days ago and I'm glad that I found this repo :) Would be nice if it's usable on phones too

before: 
<img width="800" height="388" alt="image" src="https://github.com/user-attachments/assets/af59a79c-ccce-4dec-b395-ecd5c95cbc2e" />
<img width="389" height="800" alt="image" src="https://github.com/user-attachments/assets/e0c4289f-5302-4e98-9e11-6f15d3a766f2" />

after:
<img width="389" height="800" alt="image" src="https://github.com/user-attachments/assets/4cbba4b0-d41a-4c6f-b3f6-e21afb5d1b76" />
<img width="800" height="389" alt="image" src="https://github.com/user-attachments/assets/5f6ef4fc-c557-404a-b627-ca1bb310705e" />
